### PR TITLE
Correct typo "width" to "with".

### DIFF
--- a/src/view/App/TeamsEditPage.jsx
+++ b/src/view/App/TeamsEditPage.jsx
@@ -145,7 +145,7 @@ const TeamsEditPage = {
         const inTeam = {};
         const synergiesCount = teams.reduce((amount, { synergies }) => amount + synergies.length, 0);
         const message = synergiesCount?
-            `${ teams.length } ${ lang.get('teams') } ${ lang.get('width') } ${ synergiesCount } ${ lang.get('synergies') }`:
+            `${ teams.length } ${ lang.get('teams') } ${ lang.get('with') } ${ synergiesCount } ${ lang.get('synergies') }`:
             `${ teams.length } ${ lang.get('teams') }`;
         teams.forEach(({ champions, synergies }, teamIndex) => {
             teamElements.push(


### PR DESCRIPTION
"with" is a valid string in src/data/lang/en.json, but it's looking for "width" incorrectly.
For example, on my team edit page I see "8 Teams width 13 Synergies".