### PR TITLE
5* rank 3 upgrade Catalyst Cost Update

### DIFF
--- a/src/data/model/Catalyst.js
+++ b/src/data/model/Catalyst.js
@@ -74,7 +74,7 @@ export const CATALYSTS = {
             { type: CATALYST.GOLD, amount: 271370 },
         ],
         3: [
-            { type: CATALYST.BASIC, tier: 5, amount: 6 },
+            { type: CATALYST.BASIC, tier: 4, amount: 6 },
             { type: CATALYST.CLASS, tier: 4, amount: 4 },
             { type: CATALYST.ALPHA, tier: 1, amount: 6 },
             { type: CATALYST.ALPHA, tier: 2, amount: 4 },


### PR DESCRIPTION
5* champs upgrading from rank 3 to rank 4 no longer need tier 5 basic catalysts. The now only require tier 4 basic catalysts