### PR TITLE
Running inside a docker container rather than installing NPM...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM node:6-onbuild
+EXPOSE 8080
+ENV RUNNING_IN_DOCKER true

--- a/dev/task/webpack.js
+++ b/dev/task/webpack.js
@@ -6,7 +6,7 @@ import WebpackDevServer from 'webpack-dev-server';
 import webpackConfig, { extractStylesPlugin, championIcons } from '../config/webpack-config.js';
 
 gulp.task('develop', (callback) => {
-    const domain = 'localhost';
+    const domain = inDocker() ? '0.0.0.0' : 'localhost';
     const port = 8080;
     const config = {
         ...webpackConfig,
@@ -58,7 +58,9 @@ gulp.task('develop', (callback) => {
             throw new gutil.PluginError('webpack-dev-server', err);
         }
         gutil.log('[webpack-dev-server] 🌎', `http://${ domain }:${ port }/index.html`);
-        opn(`http://${domain}:${port}`);
+        if (!inDocker()) {
+           opn(`http://${domain}:${port}`);          
+        }
     });
 });
 
@@ -109,3 +111,11 @@ gulp.task('webpack', (callback) => {
         callback();
     });
 });
+
+function inDocker() {
+  var inDocker = gutil.env.docker;
+  if (!inDocker) {
+    inDocker = "false";
+  }
+  return inDocker === "true";
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Contest of Champions Companion App",
   "main": "index.html",
   "scripts": {
-    "start": "gulp develop",
+    "start": "gulp --docker=${RUNNING_IN_DOCKER} develop",
     "lint": "gulp lint",
     "karma": "karma start",
     "karma-data": "karma start --file=./test/data/*",


### PR DESCRIPTION
Because gulp develop defaults to only binding on localhost; we have to change the domain to be 0.0.0.0 so that we can connect to it when running in docker.

- docker build -t mcoc . 
- docker run --name champions -it --rm -p 8080:8080 "mcoc:latest"


